### PR TITLE
fix add pdf luis vargas to container

### DIFF
--- a/docker/static/Dockerfile
+++ b/docker/static/Dockerfile
@@ -14,8 +14,7 @@ RUN mkdir -p \
       unzip -q -d /tmp/ /tmp/jdk.zip && \
       mv /tmp/docs/* /usr/share/nginx/html/docs/java/en/ && \
       rm -rf /tmp/jdk.zip /tmp/docs \ &&
-   curl https://lobishomen.files.wordpress.com/2011/01/libropre3.pdf --output libroluisvargas.pdf && \
-   mv ./libroluisvargas.pdf /usr/share/nginx/html/docs/assets \
+   curl -sL https://lobishomen.files.wordpress.com/2011/01/libropre3.pdf --output /usr/share/nginx/html/docs/assets/libroluisvargas.pdf
 
 FROM nginx:alpine
 COPY --from=build /usr/share/nginx/html /usr/share/nginx/html

--- a/docker/static/Dockerfile
+++ b/docker/static/Dockerfile
@@ -3,6 +3,7 @@ RUN mkdir -p \
         /usr/share/nginx/html/docs/cpp/en \
         /usr/share/nginx/html/docs/java/en \
         /usr/share/nginx/html/docs/pas/en \
+        /usr/share/nginx/html/docs/assets \
         && \
     curl -sL https://upload.cppreference.com/mwiki/images/1/16/html_book_20190607.tar.xz | \
         tar xJ --strip-components 1 -C /usr/share/nginx/html/docs/cpp && \
@@ -12,7 +13,9 @@ RUN mkdir -p \
    curl -sL https://download.oracle.com/otn_software/java/jdk/17.0.1+12/2a2082e5a09d4267845be086888add4f/jdk-17.0.1_doc-all.zip --output /tmp/jdk.zip && \
       unzip -q -d /tmp/ /tmp/jdk.zip && \
       mv /tmp/docs/* /usr/share/nginx/html/docs/java/en/ && \
-      rm -rf /tmp/jdk.zip /tmp/docs
+      rm -rf /tmp/jdk.zip /tmp/docs \ &&
+   curl https://lobishomen.files.wordpress.com/2011/01/libropre3.pdf --output libroluisvargas.pdf && \
+   mv ./libroluisvargas.pdf /usr/share/nginx/html/docs/assets \
 
 FROM nginx:alpine
 COPY --from=build /usr/share/nginx/html /usr/share/nginx/html

--- a/k8s/omegaup/base/frontend/deployment.yaml
+++ b/k8s/omegaup/base/frontend/deployment.yaml
@@ -245,3 +245,10 @@ spec:
             name: static-service
             port:
               number: 80
+      - path: /docs/assets/
+        pathType: Prefix
+        backend:
+          service:
+            name: static-service
+            port:
+              number: 80


### PR DESCRIPTION
se podia agregar el pdf al contenedor y modificar el ingress para que se sirva

Part of: https://github.com/omegaup/omegaup/issues/6292

---

Puse ese nombre de carpeta donde se guardara el pdf como placeholder pero igual no se si haya una convención o algo 