### PR TITLE
Added the mysql port as argument in cronjobs

### DIFF
--- a/k8s/omegaup/base/frontend/cronjobs.yaml
+++ b/k8s/omegaup/base/frontend/cronjobs.yaml
@@ -23,6 +23,7 @@ spec:
             command:
             - /opt/omegaup/stuff/cron/aggregate_feedback.py
             - --log-json
+            - --port=3306
             volumeMounts:
             - name: omegaup
               mountPath: /opt/omegaup
@@ -69,6 +70,7 @@ spec:
             command:
             - /opt/omegaup/stuff/cron/update_ranks.py
             - --log-json
+            - --port=3306
             volumeMounts:
             - name: omegaup
               mountPath: /opt/omegaup
@@ -115,6 +117,7 @@ spec:
             command:
             - /opt/omegaup/stuff/cron/assign_badges.py
             - --log-json
+            - --port=3306
             volumeMounts:
             - name: omegaup
               mountPath: /opt/omegaup


### PR DESCRIPTION
Adding `--port=3306` to the arguments in cronjobs.

It fixes an issue reported in [omegaup](https://github.com/omegaup/omegaup) repository

Fixes: https://github.com/omegaup/omegaup/issues/6552