### PR TITLE
Fix: Add retry logic for Azure Key Vault certificate download in cloud-init

### DIFF
--- a/terraform/files/cloud-init.yml
+++ b/terraform/files/cloud-init.yml
@@ -63,6 +63,21 @@ runcmd:
         licenseKey ${newrelic_license}
     EOF
 
+    # Wait for Azure Key Vault extension to download the certificate (up to 5 minutes)
+    echo "Waiting for Azure Key Vault extension to download certificate..."
+    for i in {1..60}; do
+        if [ -f /var/lib/waagent/Microsoft.Azure.KeyVault/omegaup-runner-vault.omegaup-runner ] && [ -s /var/lib/waagent/Microsoft.Azure.KeyVault/omegaup-runner-vault.omegaup-runner ]; then
+            echo "Certificate file found after $i attempts"
+            break
+        fi
+        echo "Attempt $i: Certificate not yet available, waiting 5 seconds..."
+        sleep 5
+    done
+
+    if [ ! -f /var/lib/waagent/Microsoft.Azure.KeyVault/omegaup-runner-vault.omegaup-runner ]; then
+        echo "ERROR: Certificate file not found after 5 minutes. omegaup-runner will fail to start."
+    fi
+
     # Split the certificate into private key and certificate chain.
     openssl pkey \
         -in /var/lib/waagent/Microsoft.Azure.KeyVault/omegaup-runner-vault.omegaup-runner \


### PR DESCRIPTION
## Description

- Wait up to 5 minutes for Key Vault extension to download certificate
- Prevents race condition where cloud-init runs before extension completes
- Fixes runners starting with empty certificate files (0 bytes)
- Resolves TLS handshake EOF errors with grader

Issue: Runners were failing to connect to grader with TLS handshake errors. Root cause: `cloud-init` attempted to extract certificates before `Azure Key Vault VM` extension had downloaded them, resulting in empty certificate files.

Tested: Applied to production VMSS, runners now have valid certificates (3.3KB + 1.7KB) and are successfully processing evaluations.