### PR TITLE
temp: Pin grader to node with EBS volume to prevent JE

### DIFF
--- a/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
@@ -8,3 +8,14 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/version: v1.9.66
+    spec:
+      # Temporary: Pin to node where EBS volume is attached to avoid detach/attach delays
+      # Remove after confirming volume can be safely moved or after migrating to EFS
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+              - ip-192-168-43-99.ec2.internal


### PR DESCRIPTION
## Description

Adds `nodeAffinity` to force pod on `ip-192-168-43-99` where `vol-02bcbe8a31a02da49` is attached to:

- Prevent multi-attach errors and Judge Errors from missing cache files
- Temporary fix until migration to EFS (ReadWriteMany)