### PR TITLE
fix: Merge nodeAffinity with existing podAffinity in grader deployment

### DIFF
--- a/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
@@ -11,11 +11,23 @@ spec:
     spec:
       # Temporary: Pin to node where EBS volume is attached to avoid detach/attach delays
       # Remove after confirming volume can be safely moved or after migrating to EFS
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values:
-              - ip-192-168-43-99.ec2.internal
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - ip-192-168-43-99.ec2.internal
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - gitserver
+              topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
Previous PR added nodeAffinity but overwrote the existing podAffinity. This fix properly merges both affinity rules so the pod:
- MUST run on ip-192-168-43-99 (where EBS volume is attached)
- PREFERS to be colocated with gitserver pod

Without this fix, pod gets scheduled on wrong node and fails to mount volume.