### PR TITLE
Migrate grader from EBS to EFS for ReadWriteMany support

### DIFF
--- a/k8s/omegaup/base/backend/deployment.yaml
+++ b/k8s/omegaup/base/backend/deployment.yaml
@@ -103,7 +103,7 @@ spec:
       volumes:
       - name: omegaup-grader
         persistentVolumeClaim:
-          claimName: omegaup-grader-pvc3
+          claimName: omegaup-grader-efs-pvc
       - name: grader-secret
         secret:
           secretName: grader-secret

--- a/k8s/omegaup/overlays/production/backend/deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/deployment.yaml
@@ -59,6 +59,6 @@ spec:
           volumes:
           - name: omegaup-backend
             persistentVolumeClaim:
-              claimName: omegaup-grader-pvc3
+              claimName: omegaup-grader-efs-pvc
           securityContext:
             fsGroup: 1000

--- a/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/grader-deployment.yaml
@@ -9,17 +9,8 @@ spec:
       labels:
         app.kubernetes.io/version: v1.9.66
     spec:
-      # Temporary: Pin to node where EBS volume is attached to avoid detach/attach delays
-      # Remove after confirming volume can be safely moved or after migrating to EFS
+      # With EFS (ReadWriteMany), no need for nodeAffinity - pod can run on any node
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - ip-192-168-43-99.ec2.internal
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 5

--- a/k8s/omegaup/overlays/production/backend/grader-efs-pv.yaml
+++ b/k8s/omegaup/overlays/production/backend/grader-efs-pv.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: omegaup-grader-efs-pv
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-04f72e99270329894
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: omegaup-grader-efs-pvc
+  namespace: omegaup
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 50Gi
+  volumeName: omegaup-grader-efs-pv

--- a/k8s/omegaup/overlays/production/backend/kustomization.yaml
+++ b/k8s/omegaup/overlays/production/backend/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../../../base/backend
 - deployment.yaml
 - grader-metrics.yaml
+- grader-efs-pv.yaml
 
 patches:
 - patch: |
@@ -23,20 +24,21 @@ patches:
       storageClassName: ""
       volumeMode: Filesystem
       volumeName: omegaup-backend-pv
-- patch: |
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: omegaup-grader-pvc3
-    spec:
-      resources:
-        requests:
-          storage: 50Gi
-      accessModes:
-      - ReadWriteOnce
-      storageClassName: ""
-      volumeMode: Filesystem
-      volumeName: omegaup-grader-pv3
+# Old EBS PVC - Replaced with omegaup-grader-efs-pvc (EFS with ReadWriteMany)
+# - patch: |
+#     apiVersion: v1
+#     kind: PersistentVolumeClaim
+#     metadata:
+#       name: omegaup-grader-pvc3
+#     spec:
+#       resources:
+#         requests:
+#           storage: 50Gi
+#       accessModes:
+#       - ReadWriteOnce
+#       storageClassName: ""
+#       volumeMode: Filesystem
+#       volumeName: omegaup-grader-pv3
 - patch: |
     apiVersion: apps/v1
     kind: Deployment

--- a/terraform/efs.tf
+++ b/terraform/efs.tf
@@ -1,0 +1,74 @@
+# EFS File System for Grader
+# This replaces the problematic EBS volume with ReadWriteMany support
+
+resource "aws_efs_file_system" "omegaup_grader" {
+  creation_token = "omegaup-grader"
+  encrypted      = true
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  tags = {
+    Name = "omegaup-grader-efs"
+  }
+}
+
+# Mount targets in each availability zone for high availability
+resource "aws_efs_mount_target" "omegaup_grader_az_a" {
+  file_system_id  = aws_efs_file_system.omegaup_grader.id
+  subnet_id       = aws_subnet.omegaup_eks_cluster_subnet_private_a.id
+  security_groups = [aws_security_group.efs_grader.id]
+}
+
+resource "aws_efs_mount_target" "omegaup_grader_az_b" {
+  file_system_id  = aws_efs_file_system.omegaup_grader.id
+  subnet_id       = aws_subnet.omegaup_eks_cluster_subnet_private_b.id
+  security_groups = [aws_security_group.efs_grader.id]
+}
+
+# Security group for EFS
+resource "aws_security_group" "efs_grader" {
+  name        = "omegaup-grader-efs-sg"
+  description = "Security group for EFS grader file system"
+  vpc_id      = aws_vpc.omegaup_eks_cluster_vpc.id
+
+  ingress {
+    description = "NFS from EKS nodes"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    security_groups = [
+      aws_security_group.eks_cluster_sg_omegaup_eks_cluster_ClusterSharedNodeSecurityGroup.id,
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "omegaup-grader-efs-sg"
+  }
+}
+
+# StorageClass for EFS
+resource "kubernetes_storage_class" "efs" {
+  metadata {
+    name = "efs-sc"
+  }
+  storage_provisioner = "efs.csi.aws.com"
+  parameters = {
+    provisioningMode = "efs-ap"
+    fileSystemId     = aws_efs_file_system.omegaup_grader.id
+    directoryPerms   = "700"
+  }
+}
+
+# Output EFS ID for migration scripts
+output "efs_grader_id" {
+  value = aws_efs_file_system.omegaup_grader.id
+}


### PR DESCRIPTION
Resolves recurring grader failures caused by EBS volume multi-attach deadlock during rolling updates. EFS mount targets configured in` us-east-1a` and `us-east-1b` with proper security groups.

- Replace `omegaup-grader-pvc3` (EBS ReadWriteOnce) with `omegaup-grader-efs-pvc` (EFS ReadWriteMany)
- Remove `nodeAffinity` constraint - no longer needed with EFS
- Add `PersistentVolume` and PVC definitions for EFS filesystem `fs-04f72e99270329894`
- Add Terraform configuration for EFS infrastructure
- EFS allows pod mobility across nodes and resolves `ContainerCreating` errors during ArgoCD sync

