### PR TITLE
Remove omegaup-grader-pvc3 from base deployment

### DIFF
--- a/k8s/omegaup/base/backend/deployment.yaml
+++ b/k8s/omegaup/base/backend/deployment.yaml
@@ -10,17 +10,6 @@ spec:
   - ReadWriteOnce
   volumeName: omegaup-backend-pv
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: omegaup-grader-pvc3
-spec:
-  resources:
-    requests:
-      storage: 1Gi
-  accessModes:
-  - ReadWriteOnce
----
 apiVersion: apps/v1
 kind: Deployment
 


### PR DESCRIPTION
This PVC was already commented out in the production overlay, but still
existed in the base deployment. ArgoCD was recreating it during sync,
causing the application to stay in Progressing state.

The grader now uses omegaup-grader-efs-pvc (EFS with ReadWriteMany) as
defined in the production overlay.