### PR TITLE
fix: use textContent instead of append for secure DOM injection 

### DIFF
--- a/docker/grader/fake/templates/index.html
+++ b/docker/grader/fake/templates/index.html
@@ -44,13 +44,13 @@
           const details = await (
             await fetch(`/submission/${submissionID}/details/`)
           ).text();
-          template.querySelector("td[data-source] pre").append(source);
+          template.querySelector("td[data-source] pre").textContent = source;
           template
             .querySelector("td[data-details] pre[data-details]")
-            .append(details);
+            .textContent = details;
           template
             .querySelector("td[data-details] pre[data-logs]")
-            .append(logs);
+            .textContent = logs;
           template.querySelector(
             "td[data-download] a"
           ).href = `/submission/${submissionID}/download`;


### PR DESCRIPTION
## Summary

Security hardening of the fake grader dashboard by replacing `.append()` with `.textContent` when rendering submission data.

## What Changed

In `onDetailsClicked`, all raw submission data (source code, logs, and details) is now injected using `.textContent` instead of `.append()`:

- Source code
- Execution logs
- Grader details

## Why

Submission data is user-controlled and should always be treated as untrusted input. Using `.textContent` ensures the content is rendered strictly as text, preventing any possibility of HTML interpretation or XSS and making the intent explicit.

## Impact

- Improves frontend security
- Aligns with modern JavaScript best practices
- No functional behavior change

Fixes: #37 