### PR TITLE
Support Docker and CRI logs in Fluent Bit

### DIFF
--- a/k8s/logging/base/fluent-bit-config/input-kubernetes.conf
+++ b/k8s/logging/base/fluent-bit-config/input-kubernetes.conf
@@ -2,7 +2,7 @@
     Name              tail
     Tag               kube.*
     Path              /var/log/containers/*.log
-    Parser            docker
+    multiline.parser  docker, cri
     DB                /var/log/flb_kube.db
     Mem_Buf_Limit     5MB
     Skip_Long_Lines   On


### PR DESCRIPTION
## Context

The production EKS cluster is temporarily running a mixed node fleet:

- Amazon Linux 2 nodes using Docker
- Amazon Linux 2023 nodes using containerd/CRI

Fluent Bit currently uses only the `docker` parser. On the new containerd nodes this causes repeated `could not translate record accessor` warnings and incomplete Loki metadata.

## Change

Replace the single Docker parser with Fluent Bit's built-in multiline parser detection:

