### PR TITLE
Use unique Loki streams for Kubernetes pods

### DIFF
--- a/k8s/logging/overlays/production/fluent-bit-config.yaml
+++ b/k8s/logging/overlays/production/fluent-bit-config.yaml
@@ -6,19 +6,14 @@ metadata:
         kustomize.config.k8s.io/needs-hash: "true"
         kustomize.config.k8s.io/behavior: merge
 data:
-    output.conf: ENC[AES256_GCM,data:cI1to8IJnXga3l9CTtmgmuoJjni0lJAUHozJespkbMzaACQyQZVVTdwQ6doEpG47r47uAW7NKZv2OZfmGkH/0draJ+Ct+nJGsvWv2IWTsQLtxf1g5lG/PcHVmlMzCZjsum7CYJRH0dxra5isjhwwQtaznBOWoFP9E7aTVgOQUjXbOUysQcE8n/4DZqumxyuFbkab+3uC9ulHBvpSHAMWrN3O8mMeYrUq4nRzK6RZCsNkeZF1gsMJ3gxBdyHu/joTNbJ+llCKNuTIpwJRmvR9rkevqXFbH/kP2SehS4bTU2vP3QxdfFFPSoPUaNlYzXWWodiQ2KCsuzlsf7H+we+Aap4oZ7pd8OyVsdaA+PGieZg8hSWGP6FEP12nzZVd+k6kHhwFOCw7NCy9yPkYSHjb5cLPk4+6UYxMu9t31jLsAV+WR/UxDUO90vx7+lJJGruBRvljtAlCzUxqDS7y9pMrXwzHWF9dEWlHS6oWy1zv6OCcm9yIoBRrbMg9oIIC5Xc0FvXUg9gCuGjuVyNkVQZTKqrWzTFBGfPIkzRnH38RBRGwqi94uyr+RxIh,iv:lYzWC1P7A+2zszWvdbco+QM3b7bYSsdhCBrFL0Qr7Go=,tag:ZvYPEOl88eXHp605YlG/nA==,type:str]
+    output.conf: ENC[AES256_GCM,data:CEuJxsfAMTdkOG+GQB4ZnyHNWJytyNIZUAyRxAKXEjx4ASjtyMV2Adj0dd45F3Aidbx0+DKMeM9xgoG8sJ3FZCgtn15it6z+jf5PWdD1WDAprJaPjoXOGvU4Fxn60qq+ephWP4d8pDkOTgtz1QxGZJ9WGrvAlDdYKcS48vLunsGAERJROoRIlrhoAyPl5zlUgXWKIJmFtfXEOLUjeug/An8KcyFpeb+Egc1TYOlAYA+e5OFza//zjeobVupnZOOwzQ6ro2ZFMgUUoZe3T+NwMFFE8/i/QCyVaWljBu9qWs0k31wG8Ez9ruTH6o5Bel6yWj1Xo2cj6e2JzzadaBSvMJJ64Yx59BMq2wUi6AuluXV+kMA8O++4Po+j04/i7JvogU2BhWoveCVUR6vyohodkgbwmcI5c15G8n+QKDlxFn9FR2EASWovMiM/ePWrvhStwzUEshnFtd4e7MebrEm1ypreykUzm2eB+jCExaY0gSIWpSjle9tcIGJ6KR+tGGsBTTu3/x8xcXec7CkvjomlDynQ0VBUODkresrnsy5qlZps2iZw+5LKkA==,iv:a564/Ca90ifvNIV47OzQwMnGgRJ4x5XJ7t/8iMFJKOI=,tag:MoEJJ0R2CzWSS54ozj7ONQ==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
           created_at: "2021-12-10T14:52:10Z"
           enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQEmI3Q0Kz8eFp9PtBDBBJr8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMgqQnHRUn/TTaEgyKAgEQgDtLIMpckG5ZNOuLxdF8rSQMS+CbFvOu+B8rXueMDb4mVqjwEqXqYysDQZzJwF+4TW84fr0xtycCBiP2gQ==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2021-12-10T15:02:56Z"
-    mac: ENC[AES256_GCM,data:RUmGv0JDfgZGL3LUQBmhhfFfjrBqDv4O3CxZTdELpDB6aKPaMTzvCO8X33YxnpWBPTulWBevtckav6amkSAp2JKtCNVDPsMt9Vaboij74E08bl2pfG6W3J9Worx7qiXJxxcdBq5QctWXquH58kdBfqbe4to/NNgIY9/bb00KIUM=,iv:YZUDr86QtlEWOTlVOK8QfTJ80Ek5/VVthGfwBysb8BI=,tag:Z3V0tRrQ6Rls5mh3Ee+UAw==,type:str]
-    pgp: []
+    lastmodified: "2026-07-18T22:07:17Z"
+    mac: ENC[AES256_GCM,data:r/SYsejAC3TF0yt96NrhumEQZdmcfFqJt4Pjg8iHhXSyoHKYX/aKIjEgos8pfqklDyKzFeuVlWQ9Aa+U1CN/aaUbhzDDpuX+hXwddfzCTcim7NMY+ueJbW8TzKP1nocc8QGdnPWerQyRZTk0toP3+RjdLiSXdm5/xzOtbGeoel8=,iv:ncJlhAlp789kDOLMJZw8+DT164rOsWkEYTxvWZSejL0=,tag:Cl7gMsw68ISE6hHJ+NhYDQ==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.12.2


### PR DESCRIPTION
Use unique namespace, pod, and container labels for Loki streams to prevent out-of-order log rejection. SOPS also removed unused empty encryption-provider fields