### PR TITLE
Add persistent storage for Loki

### DIFF
--- a/k8s/grafana/overlays/production/kustomization.yaml
+++ b/k8s/grafana/overlays/production/kustomization.yaml
@@ -8,6 +8,8 @@ commonLabels:
 
 bases:
 - ../../base
+resources:
+- loki-storage.yaml
 configMapGenerator:
 - name: grafana-config
   files:

--- a/k8s/grafana/overlays/production/loki-storage.yaml
+++ b/k8s/grafana/overlays/production/loki-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: loki-gp3-retain
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  fsType: ext4
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: loki-gp3-retain
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
Add a retained 20 GiB gp3 volume for Loki. This provisions persistent storage without modifying or restarting the current Loki deployment. The volume will be populated before Loki is updated to mount it