### PR TITLE
Mount Loki data on persistent storage

### DIFF
--- a/k8s/grafana/overlays/production/kustomization.yaml
+++ b/k8s/grafana/overlays/production/kustomization.yaml
@@ -27,6 +27,25 @@ generators:
 - grafana-secret-generator.yaml
 patches:
 - patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: loki-deployment
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+          containers:
+          - name: loki
+            volumeMounts:
+            - name: loki-data
+              mountPath: /loki
+          volumes:
+          - name: loki-data
+            persistentVolumeClaim:
+              claimName: loki-pvc
+- patch: |-
     - op: replace
       path: /spec/rules/0/host
       value: grafana.omegaup.com


### PR DESCRIPTION
Mounts the production Loki PVC at /loki and schedules Loki on the
AL2023 managed node group.

The existing 4.9 GiB of Loki data was copied to the PVC and the
production rollout was validated successfully.