### PR TITLE
Schedule Prometheus on AL2023 nodes

### DIFF
--- a/k8s/grafana/overlays/production/kustomization.yaml
+++ b/k8s/grafana/overlays/production/kustomization.yaml
@@ -103,6 +103,8 @@ patches:
     spec:
       template:
         spec:
+          nodeSelector:
+            eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
           containers:
             - name: prometheus
               volumeMounts:


### PR DESCRIPTION
Schedules production Prometheus on the AL2023 managed node group while preserving its existing PVC