### PR TITLE
Rotate New Relic license keys

### DIFF
--- a/k8s/logging/base/deployment.yaml
+++ b/k8s/logging/base/deployment.yaml
@@ -51,6 +51,12 @@ spec:
       - name: fluent-bit
         image: omegaup/fluent-bit:1.8.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: NEW_RELIC_LICENSE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fluent-bit-newrelic-secret
+              key: license-key
         ports:
           - containerPort: 2020
         resources:

--- a/k8s/logging/overlays/production/fluent-bit-config.yaml
+++ b/k8s/logging/overlays/production/fluent-bit-config.yaml
@@ -6,14 +6,14 @@ metadata:
         kustomize.config.k8s.io/needs-hash: "true"
         kustomize.config.k8s.io/behavior: merge
 data:
-    output.conf: ENC[AES256_GCM,data:CEuJxsfAMTdkOG+GQB4ZnyHNWJytyNIZUAyRxAKXEjx4ASjtyMV2Adj0dd45F3Aidbx0+DKMeM9xgoG8sJ3FZCgtn15it6z+jf5PWdD1WDAprJaPjoXOGvU4Fxn60qq+ephWP4d8pDkOTgtz1QxGZJ9WGrvAlDdYKcS48vLunsGAERJROoRIlrhoAyPl5zlUgXWKIJmFtfXEOLUjeug/An8KcyFpeb+Egc1TYOlAYA+e5OFza//zjeobVupnZOOwzQ6ro2ZFMgUUoZe3T+NwMFFE8/i/QCyVaWljBu9qWs0k31wG8Ez9ruTH6o5Bel6yWj1Xo2cj6e2JzzadaBSvMJJ64Yx59BMq2wUi6AuluXV+kMA8O++4Po+j04/i7JvogU2BhWoveCVUR6vyohodkgbwmcI5c15G8n+QKDlxFn9FR2EASWovMiM/ePWrvhStwzUEshnFtd4e7MebrEm1ypreykUzm2eB+jCExaY0gSIWpSjle9tcIGJ6KR+tGGsBTTu3/x8xcXec7CkvjomlDynQ0VBUODkresrnsy5qlZps2iZw+5LKkA==,iv:a564/Ca90ifvNIV47OzQwMnGgRJ4x5XJ7t/8iMFJKOI=,tag:MoEJJ0R2CzWSS54ozj7ONQ==,type:str]
+    output.conf: ENC[AES256_GCM,data:QLHTi2Ui2BYvoBs2qjoOco6ew74vBLcryVf31pXt8UOnm3WUfVs7dyvjv05lNtT05qMvuEARjTl94tw4AAOVFvaRlO/zSngsRiWnIfXZuZ8GWHlmDkg2Cugyo20O0g8TOb0cn3VyX43jya5TT7ax61lxjP6IRjyi8exr6mRQDrvDcZbCdJwJMh7HAvqvydcULRsgavZPpoWkCmf18SDL4QxdXC1TlZARXcTFeEOkKIzxzQVU5/TRUVYgW9/nQGMoWZ3lXs11/EAaQNfhx4Tom4Rp2H/SR4hLZK3zGeSKw0mxO7lzAdtoqNKmJDl0oJiFNAmZyG8voZJn58QwNvJdXJ3s4gJnLb2jBk7YJjYcqgTqxD2F9OnsOKEQyXWbgtuAgfreIwmpE2BaNW9lCDnDn3cZuv6ZMprkNin8knxdl92EFkmjhR0DWPO13k0autu9fsO35acoXOXQXVfJvPMhJ3Ovo/usF6ibpfwVLRATKq71Tn1wsigmBhkEUs3Nr79lzOMlTpTWPkjuB1CAeG1VEz9XdTfqbH4+,iv:YwoVT7mcUUtxJZUxibwdaLQDZ7f9XgynkgSeRYYyFcw=,tag:dNiN81TUDQdeKUnz+exDcA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
-          created_at: "2021-12-10T14:52:10Z"
-          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQEmI3Q0Kz8eFp9PtBDBBJr8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMgqQnHRUn/TTaEgyKAgEQgDtLIMpckG5ZNOuLxdF8rSQMS+CbFvOu+B8rXueMDb4mVqjwEqXqYysDQZzJwF+4TW84fr0xtycCBiP2gQ==
+          created_at: "2026-07-24T21:08:54Z"
+          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQGc7ZaDvnE6puPHyFJerprIAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMtXgJT8rNNk1xTctZAgEQgDuBr0WHeDNUkv3FTOWI71Q9M1A5TWTmIQs7m3kpuBktQEp1Bh+TQdU6dajsWX5gJcnHqLFMCFmlOVqN7g==
           aws_profile: ""
-    lastmodified: "2026-07-18T22:07:17Z"
-    mac: ENC[AES256_GCM,data:r/SYsejAC3TF0yt96NrhumEQZdmcfFqJt4Pjg8iHhXSyoHKYX/aKIjEgos8pfqklDyKzFeuVlWQ9Aa+U1CN/aaUbhzDDpuX+hXwddfzCTcim7NMY+ueJbW8TzKP1nocc8QGdnPWerQyRZTk0toP3+RjdLiSXdm5/xzOtbGeoel8=,iv:ncJlhAlp789kDOLMJZw8+DT164rOsWkEYTxvWZSejL0=,tag:Cl7gMsw68ISE6hHJ+NhYDQ==,type:str]
+    lastmodified: "2026-07-24T21:08:55Z"
+    mac: ENC[AES256_GCM,data:Gj60Xk6C10FrYOEwTYvPjlMNHM+3NnEa8A/L7kIH+ZaoFBmcgFUiAICn6NI7gxDQ+vMZ6WvmgHlitSIQAcHJHogT4CIPgJ7QOAuvng0MSC/R0h3adez0LmeNx6TcxEMKqKVd3iZzniP8w1z7HcITQCORHDm8R6WFGM/X00cmYSA=,iv:OG7ikgYFRMFgQkoi61paTjHlXZ1hK+S0VhBuJpInVqg=,tag:zqPgSV+a3t2OrWXT+t5gyw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/logging/overlays/production/fluent-bit-newrelic-secret-generator.yaml
+++ b/k8s/logging/overlays/production/fluent-bit-newrelic-secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: fluent-bit-newrelic-secret-generator
+files:
+  - fluent-bit-newrelic-secret.yaml

--- a/k8s/logging/overlays/production/fluent-bit-newrelic-secret.yaml
+++ b/k8s/logging/overlays/production/fluent-bit-newrelic-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: fluent-bit-newrelic-secret
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+type: Opaque
+stringData:
+    license-key: ENC[AES256_GCM,data:TY4QcrRQRUCOdb0Z64Pd/e6pS4RyDcezNhZiaClyrDmCYZveQsahkA==,iv:cHwUgnN9KQvkZDtovTRXtVC8bpFqiV7sRGtCVzWNqNo=,tag:sBSbkWw4ezz+egXCxOYUOg==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
+          created_at: "2026-07-24T21:08:55Z"
+          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQHyh744v8ZMwP+nUlFl2mUVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNJmb2dap7XI/WybYAgEQgDt+KqmnVzude8NhuUIBp5C8EtW5gIfaAKiDq8rgNWPVoXZo6vQXbuhAgXXmXsGhFhDBV+9Osovhik3RXQ==
+          aws_profile: ""
+    lastmodified: "2026-07-24T21:08:55Z"
+    mac: ENC[AES256_GCM,data:CzxphSl7CW7liR65YeEW4mT5XdmU2m0ADdsTVZtFFGiQ8RE4SpsTeFIvBFWWWvFcUPMEvf0R0m5C+M0w4xJvjO6D0U/4g5mOzjkgFf2wHiRClKTtFM34aUzAvfa4eNTrDqXmQ23GExe602kyMI/gyHz2hQTGXdMl/caudblajF0=,iv:oGSlSOcH13lhyEgown2jqekKuuR7TjupHPSOLeTiwSs=,tag:A0MLSShzv/OxWKJYAzXx+A==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/k8s/logging/overlays/production/kustomization.yaml
+++ b/k8s/logging/overlays/production/kustomization.yaml
@@ -11,3 +11,4 @@ bases:
 
 generators:
 - fluent-bit-config-generator.yaml
+- fluent-bit-newrelic-secret-generator.yaml

--- a/k8s/omegaup/overlays/production/frontend/newrelic-secret.yaml
+++ b/k8s/omegaup/overlays/production/frontend/newrelic-secret.yaml
@@ -6,19 +6,14 @@ metadata:
         kustomize.config.k8s.io/needs-hash: "true"
 type: Opaque
 stringData:
-    newrelic.ini: ENC[AES256_GCM,data:CEJEMsy8YFZ6qlwtE5qoaHbWduSwCAAneEsgf+dH6Jacz0t6OqansriQ351z1G8vO5Cs+Yq0iEyCwJvFOvpAXupb78AuhVFS+RnoYgzUJcgKqdIacncklJC5ib/rd02nVuZixh+tbDVryTMG7aUBQQKd1BQp+sUyeT5DQ4NMBYrNBjKpIC7XLYWHPZone2Vk8j85snb2KL1lfh6dm0YdPeslxzjKAt3r786k2lrFxuX9q4HIWpYgzBevQhqv84PwwQrje7eTHzLzC9KOgCiatIl57zmbfxY6WO9HAyXee0Pr5wt2AanMre/aPHoJFMzTikEMSDCWr/PiyDEY09rae2wrTeFZDiwJ9Ikjhytyiui3NeSNqMz9IHnlOQkp1HX1oo7Q2bpn4Ph1cJNNHx5Jbk6Q6ZhXQzUgdRzoqzVl7GkYTR0xtT8cyRM5rWQYzUBW7uOnA/Qq0xhl33z8tFZ5BLYQ346ZPwXodsvc7RTCfxFJjkkLaKZPyw4xcNuE9wHhYQ/KrAjUJ+oyPLPZtsdjIgJqaMFo,iv:iTsTB0rbe9OmTy0iYE+RRn3rkq+VqPc7BWNwSqkpHFM=,tag:eN6mnCQid1Osvq5afVl+sA==,type:str]
+    newrelic.ini: ENC[AES256_GCM,data:39lYVD/7L5JP3YZ+ZMMgKI/LrvUkrAbjjuvAvqYnCO/TKVsEVMo6jCWhenbyr8W2k9Ct1SikgV2f71OWfK4mY0w03JgQYIjLdLPHrianzXEP/Jgf8LApvJUPOcm0D003CNTd8ehDpFK3T824BXWj2iBdQCx1Dmm00iEzEHPrJVtaqFQvSqQ1PLl62X5j2plmvr2WKq0beUAw4gDmx4OMmwPiynW3rnTRYT3jwgsn6IN9AGjZNt2VkxfyYroL4/FeJR+Fp/jO0HfNRskTsu9tDsa0pQUEADzXnUr8Alo92xqAIr9R2JzOiTBTYDaCTIeXpQKe2EqoozSIhUyIe9yfXf34QNYvwa2M/hGyYXqR7JZAVZJfv4+1NdCoDuxY/kh+j6GhwCI+zxmp6Pi8nzB/FtRzdiCxChbgv6jcOoD0bAJjivOCcq1yj2v1g5aImGc1rwhVg+NTIYWU0K4BTq/GUk5L13pl5aqsMS8nCZJJBsQocPL2Dh7cciah6wGvAKBwMBokRhPaKVIfdf60PNw7lQHt5eAB,iv:RDGOGUd499KoHqzCAfGIVA4lVoAnJZ/vQ5YJAK+lGBM=,tag:n1N7w2gh07nY44Gc7VPzbw==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
-          created_at: "2021-11-27T13:45:49Z"
-          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQFXxnfFaChIpJot/lj045WaAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMzUcAOHaVHBlYzZ+ZAgEQgDt6HwS1MSmJJeSicuyc/NJkMtVyAgAEe/QU+YJVPaLmxhzMqEXlkLo/C2ns/jeJ9ki7GeHHpmJq8udIpw==
+          created_at: "2026-07-24T21:08:54Z"
+          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQGxc5ZHrBcMAECaUyQCBb01AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/1mkGQkGdsJM83ynAgEQgDvdOFds56TVT31GB7nHDTnqnIp27DR8mxRgI0nnkZVXFajUqABLYelWW6CNI6fLv45TWz2rYQsNEna35Q==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2021-11-27T14:17:10Z"
-    mac: ENC[AES256_GCM,data:4sG+7YKJKne+MBj8wOzP6rvfN4bq+MOo/TOA+y4/IIjpgFpBVaNcbxerM2rSbPYsWj/ktQeMIqQ+GZLbwPKur+ANeCByEY+T5TqwhVBUVJorSNluDxpBm1oN0k2SJEFGzJjcwn9Kuak2f5GPmAlOrevgOsmaDmW+FSvE2QU1ldQ=,iv:EPjOHL0nlhRoE3f7GN5eJHKQUlXXry4A5uwFFaLr0qg=,tag:ZLODuS4+I+rH14/C6Nz/Aw==,type:str]
-    pgp: []
+    lastmodified: "2026-07-24T21:08:54Z"
+    mac: ENC[AES256_GCM,data:KkyukEk8BPzkSxlK0xxHeraXqlp9RYRmedM4IDXSEpTmw2/GuBF4Coz1QZSUdQNYmePOWGcj5om6oDBsGHXNg92Irx4Pd5U3c/pM5eoR9QZFH9olJ8LhD6MJTlG61JKcwO7/qmnvrWuG0fBoVv7rkHu3feF5PYH3BwBTmySZvyQ=,iv:h90Zo/h4PwkMjUo4i6OiW6KJRPB0aHcQAdIMzkVcXYE=,tag:awDQSZSBW2p+ruGOBMSWMg==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.12.2

--- a/k8s/omegaup/overlays/sandbox/frontend/newrelic-secret.yaml
+++ b/k8s/omegaup/overlays/sandbox/frontend/newrelic-secret.yaml
@@ -6,19 +6,14 @@ metadata:
         kustomize.config.k8s.io/needs-hash: "true"
 type: Opaque
 stringData:
-    newrelic.ini: ENC[AES256_GCM,data:+FXOG/pksr0qLczoifGKHEvGne0ViycnlNDJ3AnX9rVisRTJMqgMGNVC3JX3DGyb9bPiS64L/TfF2hD2AbsfMaIbEAyasjr+U3Y1fsH30xdZpm4Jfb4qGeePxENLVocXt13iXVJ1St0Dqu3vZ38Sd7cE0Sgqlh/g7Gldz3Ddz3KsHsQaVSAKleQeqI9hTVpxaJdJ5KYy2AR1MagwVD7Uv3hdTCni9R78LFpXi0sMOlGkAhNG3TKSoMmhSaCYU2OgZ8/yV9KxbecGcf36KXNYN7csBw0XTFrYiveyJ1ilcfLoKnbPNkSPWYQvxOKZShcRbUf7C3tbUZqUxr36BqFAH8tqnQIb4Aye/vM/aHpchqV+9rlM3cvtmpZOIoj4OvWvSH1pFXecH38geuPJ8r+Xnp0aEhYc3/7Lznp28JMG0Sxsa1O5tDaNKklxg0+NqMpXJZGflSCQblmpHA+kD886ktrRQaL1tEnXs50hpfzVZNo4JMOVX158DX7xiv2opGB6LtWreYoP9fLD4PuczWT/WKk5fJv1vpF2Z+ewKOA=,iv:f3DrUhEJQAZ284ef93p5fF/cbgL+4l770oK76yEbrBU=,tag:+mQJ6+Dsrue5jz80+84Xnw==,type:str]
+    newrelic.ini: ENC[AES256_GCM,data:aA75zQsYEAUQ+YWykSHHpjldUoWTSTStdWp6ffNLnrwMDX7KX2anoBkA268bSldmo5Oz6hbrP3vjvr+dULZ6ylEhePS4dAt7FqUcxglttXVYbtPgMlqLDlZFrD9TVICNvE8H3t5BKN7zRSEOvP8QFm+aZOp8nUrgAsD4G27WabxlTicstFl+sNLocwEVJTIaxpiXE0DugZSvJXb8OVRgAm8Nvo6w+XLB1/BWWS+gCDreSlacIJHksaiITrOMlXEtQkD6OqeedEFQX7lw7De9eKZAhaIXSBWXbKDtKi/j0vgW8v/c1EbmEUqzPl9zQuWAr3smTz7Z3JPXnA/7BA0NQaGAQok5Fn8GNXZD+vnHu76Fx2SGmKJIJcM9oSjhb6L8EOKBFAMeY934G+ALdDJrrmdwVyjV6a6owkiUNXEEFlEyyDgPkvyaVgupFjpc/9iEJjPR/mGnj+sTM57apwLYEbx7dZ6hEfN1g1voVIT3c/mVhNL3XCMbPN44lN6MDUGVvXh0fMbakgn1XK3z79X5eHzdUb/gfEekn9FQbkQ=,iv:p0WHu6kcZOPGCF2MDo9raN5WlSw1nXMKQ66tkd8AR20=,tag:GJQtdR1TzRBOFWMKffo6AA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
-          created_at: "2021-11-27T13:45:49Z"
-          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQFXxnfFaChIpJot/lj045WaAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMzUcAOHaVHBlYzZ+ZAgEQgDt6HwS1MSmJJeSicuyc/NJkMtVyAgAEe/QU+YJVPaLmxhzMqEXlkLo/C2ns/jeJ9ki7GeHHpmJq8udIpw==
+          created_at: "2026-07-24T21:08:54Z"
+          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQECQMjpr80WqIeBGsZbeyQEAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMv8iqgUdvUdBW8dafAgEQgDsCZdeOHWAG90fy5cGTm7m8kVF2/NUl47HtvKR2qEdgxC4QwA8UJGyMd8OUATWvLuvWtrw5CRoAzkcWDg==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2021-11-27T14:00:08Z"
-    mac: ENC[AES256_GCM,data:5NIvvrYtfqz75wnncTYtn3ytcVQVd3+fiWgfSezPDqh3qLVt34Q0h5BX6oDD5khYI0AHr0tim/zQtkYsI1mtNBgauC4gzpvvp/5IL9dHFrfkWkBSxULRbrEKQ8pUaUgXuOtOBINAlYJH1oSd9T8XlDLeqyVq15NyF+sf3dQlQgE=,iv:ShL914heYKA3pYDqMiO5S/o/p8ZfT7Rh2GS63ibhFZI=,tag:9xIUYWiNLmSvPNwP74OtqQ==,type:str]
-    pgp: []
+    lastmodified: "2026-07-24T21:08:54Z"
+    mac: ENC[AES256_GCM,data:nSJt6UimyYFTMENQRAaXfyC1uW5Cxxf1D3wzaBlxOjBFvCjx0Onkrn6ZIDntS3TQn799cEQCvS2YRb/Ze53vWaQJoDXVCBMWK4shFl4RXnCUP0lE0iwUMVU4rZn1DW9ad5WgJt9A6pc+7/VYfTcL6PIHm/bBh6hUtKH/SrKEzSY=,iv:b2YmBPL1myXrK/zEnrSzqyWigh9MLA71hvNH1wpE47c=,tag:VsvB59O2Bc3zT/KmTD7pxg==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.12.2


### PR DESCRIPTION
Rotates the New Relic ingest license keys for Fluent Bit and the production and sandbox PHP agents. Moves the Fluent Bit key from its ConfigMap into a SOPS-encrypted Secret