### PR TITLE
Forward grader metrics to New Relic via Prometheus remote_write

### DIFF
--- a/k8s/grafana/overlays/production/kustomization.yaml
+++ b/k8s/grafana/overlays/production/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
   - prometheus-config/scrape-configs/runners.yml
 generators:
 - grafana-secret-generator.yaml
+- prometheus-newrelic-secret-generator.yaml
 patches:
 - patch: |-
     apiVersion: apps/v1
@@ -129,7 +130,14 @@ patches:
               - name: prometheus-config
                 mountPath: /etc/prometheus.tmpl/scrape-configs/runners.yml
                 subPath: runners.yml
+              - name: prometheus-newrelic-secret
+                mountPath: /etc/prometheus/secrets/newrelic-license-key
+                subPath: license-key
+                readOnly: true
           volumes:
           - name: prometheus-config
             configMap:
               name: prometheus-config
+          - name: prometheus-newrelic-secret
+            secret:
+              secretName: prometheus-newrelic-secret

--- a/k8s/grafana/overlays/production/prometheus-config/prometheus.yml
+++ b/k8s/grafana/overlays/production/prometheus-config/prometheus.yml
@@ -3,7 +3,7 @@
 # Anything that is NOT a scrape config must therefore appear ABOVE the
 # `scrape_configs:` key, and `scrape_configs:` must remain the last line.
 remote_write:
-  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=omegaup-eks
+  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=omegaup-eks-cluster
     authorization:
       credentials_file: /etc/prometheus/secrets/newrelic-license-key
     write_relabel_configs:

--- a/k8s/grafana/overlays/production/prometheus-config/prometheus.yml
+++ b/k8s/grafana/overlays/production/prometheus-config/prometheus.yml
@@ -1,1 +1,19 @@
+# NOTE: the prometheus container builds its runtime config by appending each
+# file in scrape-configs/ to the end of this file (see grafana/base/deployment.yaml).
+# Anything that is NOT a scrape config must therefore appear ABOVE the
+# `scrape_configs:` key, and `scrape_configs:` must remain the last line.
+remote_write:
+  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=omegaup-eks
+    authorization:
+      credentials_file: /etc/prometheus/secrets/newrelic-license-key
+    write_relabel_configs:
+      # Ship only the series New Relic alerts on. Everything else (node-exporter,
+      # cadvisor, apiserver, ...) stays in Prometheus/Grafana and costs nothing.
+      - source_labels: [__name__]
+        regex: 'quark_grader_.*'
+        action: keep
+      # runner_public_ip churns every time a VMSS instance is replaced, which
+      # creates a new time series each time. runner_hostname is the stable identity.
+      - regex: runner_public_ip
+        action: labeldrop
 scrape_configs:

--- a/k8s/grafana/overlays/production/prometheus-newrelic-secret-generator.yaml
+++ b/k8s/grafana/overlays/production/prometheus-newrelic-secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: prometheus-newrelic-secret-generator
+files:
+  - prometheus-newrelic-secret.yaml

--- a/k8s/grafana/overlays/production/prometheus-newrelic-secret.yaml
+++ b/k8s/grafana/overlays/production/prometheus-newrelic-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: prometheus-newrelic-secret
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+type: Opaque
+stringData:
+    license-key: ENC[AES256_GCM,data:TY4QcrRQRUCOdb0Z64Pd/e6pS4RyDcezNhZiaClyrDmCYZveQsahkA==,iv:cHwUgnN9KQvkZDtovTRXtVC8bpFqiV7sRGtCVzWNqNo=,tag:sBSbkWw4ezz+egXCxOYUOg==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
+          created_at: "2026-07-24T21:08:55Z"
+          enc: AQICAHik82tDrWUjAnFKor0DW0Qtxt+MUW7jXDsQO0uycf6klQHyh744v8ZMwP+nUlFl2mUVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNJmb2dap7XI/WybYAgEQgDt+KqmnVzude8NhuUIBp5C8EtW5gIfaAKiDq8rgNWPVoXZo6vQXbuhAgXXmXsGhFhDBV+9Osovhik3RXQ==
+          aws_profile: ""
+    lastmodified: "2026-07-31T00:06:42Z"
+    mac: ENC[AES256_GCM,data:BybOyPOnVSivI417yCTd3Hcrx4nZf0xReOg0jCd/6osYZydDqgGHP7WIrun8WfQoXe8X+vmPC4qYbVk5IEWpXWdAWjMmtRUt7xWuL+Cz0rLStr2XjDGuLU3dFKoQQSBmuYPEWSuqBEYqqxRwVrHbKvYT4MJLM812b1oOXXq5waw=,iv:TlkZL5O8rowIBikWzpq++M4gAVWzDKHCrhf21fBDMQc=,tag:R4UZiP9vmqZrO1FUHwJkDg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2


### PR DESCRIPTION
The grader queue, runner fleet and JE metrics live only in the in-cluster Prometheus, so nothing outside the cluster can alert on them and a contest-time queue backup is invisible until users complain.

Add a remote_write target on the existing Prometheus rather than deploying nri-bundle: this repo is kustomize + ArgoCD + ksops throughout with no Helm anywhere, and Prometheus already scrapes the grader via the kubernetes-service-endpoints job. No new workloads, no new tooling.

Only quark_grader_* is forwarded; node-exporter, cAdvisor and apiserver series stay in Prometheus/Grafana. runner_public_ip is dropped because it churns on every VMSS instance replacement, creating a new time series each time; runner_hostname is the stable identity.

Note: the prometheus container assembles its runtime config by appending each scrape-configs/*.yml to the end of prometheus.yml, so remote_write must sit above scrape_configs:, which has to remain the last line.