### PR TITLE
Migrate production Redis to AL2023 storage

### DIFF
--- a/k8s/omegaup/overlays/production/frontend/kustomization.yaml
+++ b/k8s/omegaup/overlays/production/frontend/kustomization.yaml
@@ -13,6 +13,7 @@ commonLabels:
 resources:
 - ../../../base/frontend
 - database.yaml
+- redis-storage.yaml
 
 generators:
 - cronjobs-secret-generator.yaml
@@ -437,6 +438,7 @@ patches:
     kind: Deployment
     name: frontend-deployment
     version: v1
+- path: redis-deployment.yaml
 
 images:
 - name: omegaup/ai-editorial-worker

--- a/k8s/omegaup/overlays/production/frontend/redis-deployment.yaml
+++ b/k8s/omegaup/overlays/production/frontend/redis-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+      containers:
+      - name: redis
+        image: redis:7.4.3
+        command:
+        - redis-server
+        - /etc/redis/redis.conf
+        - --maxmemory
+        - 200mb
+        resources:
+          limits:
+            cpu: 50m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 128Mi
+      volumes:
+      - name: redis-persistent-storage
+        persistentVolumeClaim:
+          claimName: redis-pvc-v2

--- a/k8s/omegaup/overlays/production/frontend/redis-storage.yaml
+++ b/k8s/omegaup/overlays/production/frontend/redis-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: redis-gp3-retain
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  fsType: ext4
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc-v2
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: redis-gp3-retain
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Moves production Redis to a retained gp3 PVC on the AL2023 node group.
Pins Redis 7.4.3, uses a Recreate strategy, and increases the Redis memory
headroom to prevent evictions during the storage migration.