### PR TITLE
Keep Redis StorageClass outside ArgoCD

### DIFF
--- a/k8s/omegaup/overlays/production/frontend/redis-storage.yaml
+++ b/k8s/omegaup/overlays/production/frontend/redis-storage.yaml
@@ -1,15 +1,3 @@
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: redis-gp3-retain
-provisioner: ebs.csi.aws.com
-parameters:
-  type: gp3
-  fsType: ext4
-reclaimPolicy: Retain
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
Removes the cluster-scoped Redis StorageClass from the frontend ArgoCD
overlay because the omegaup project cannot manage cluster-scoped resources.
The existing StorageClass remains in the cluster, while ArgoCD continues
managing redis-pvc-v2 and the Redis Deployment.