### PR TITLE
Limit production PHP-FPM worker pool

### DIFF
--- a/k8s/omegaup/overlays/production/frontend/kustomization.yaml
+++ b/k8s/omegaup/overlays/production/frontend/kustomization.yaml
@@ -30,6 +30,10 @@ configMapGenerator:
   - nginx-config/grader-upstream.conf
   - nginx-config/realip.conf
   name: nginx-config
+- behavior: merge
+  files:
+  - php-config/php-fpm.conf
+  name: php-config
 
             # TODO: Remove once we migrate to jammy.
             # TODO: Remove once we migrate to jammy.

--- a/k8s/omegaup/overlays/production/frontend/php-config/php-fpm.conf
+++ b/k8s/omegaup/overlays/production/frontend/php-config/php-fpm.conf
@@ -1,0 +1,31 @@
+[global]
+error_log = /var/log/php-fpm.log
+process_control_timeout = 5
+
+[docker]
+listen = /run/php/php-fpm.sock
+listen.backlog = -1
+
+pm = dynamic
+pm.max_children = 32
+pm.start_servers = 8
+pm.min_spare_servers = 5
+pm.max_spare_servers = 10
+pm.max_requests = 200
+
+ping.response = pong
+
+php_admin_flag[display_errors] = off
+php_admin_flag[display_startup_errors] = off
+php_admin_value[error_reporting] = E_ALL & ~E_DEPRECATED & ~E_STRICT
+php_admin_value[memory_limit] = 1024M
+php_admin_value[post_max_size] = 200M
+php_admin_value[upload_max_filesize] = 200M
+php_admin_flag[apc.enable_cli] = on
+php_admin_value[opcache.consistency_checks] = 0
+php_admin_flag[opcache.file_cache_consistency_checks] = off
+php_admin_flag[opcache.validate_timestamps] = off
+
+slowlog = /var/log/php-fpm-slow.log
+request_slowlog_timeout = 0
+catch_workers_output = no


### PR DESCRIPTION
Limits the production PHP-FPM pool to 32 workers, reduces the number of idle workers retained after traffic bursts, and recycles workers more frequently. This mitigates the risk of OOM kills and 502 errors without changing memory limits, caching, or other environments.