### PR TITLE
Move sandbox Redis to retained AL2023 storage

### DIFF
--- a/k8s/omegaup/overlays/sandbox/frontend/kustomization.yaml
+++ b/k8s/omegaup/overlays/sandbox/frontend/kustomization.yaml
@@ -39,6 +39,7 @@ configMapGenerator:
 resources:
 - ../../../base/frontend
 - database.yaml
+- redis-storage.yaml
 
             # TODO: Remove once we migrate to jammy.
             # TODO: Remove once we migrate to jammy.
@@ -1284,6 +1285,7 @@ patches:
     kind: Deployment
     name: frontend-deployment
     version: v1
+- path: redis-deployment.yaml
 
 images:
 - name: omegaup/ai-editorial-worker

--- a/k8s/omegaup/overlays/sandbox/frontend/redis-deployment.yaml
+++ b/k8s/omegaup/overlays/sandbox/frontend/redis-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+      containers:
+      - name: redis
+        image: redis:7.4.2
+        command:
+        - redis-server
+        - /etc/redis/redis.conf
+        - --maxmemory
+        - 200mb
+        resources:
+          limits:
+            cpu: 50m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 128Mi
+      volumes:
+      - name: redis-persistent-storage
+        persistentVolumeClaim:
+          claimName: redis-pvc-v2

--- a/k8s/omegaup/overlays/sandbox/frontend/redis-storage.yaml
+++ b/k8s/omegaup/overlays/sandbox/frontend/redis-storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc-v2
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: redis-sandbox-gp3-retain
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Migrates sandbox Redis to AL2023 using Redis 7.4.2 and a retained gp3 PVC, preserving the recovered data and improving storage safety