### PR TITLE
Move Grafana to AL2023

### DIFF
--- a/k8s/grafana/overlays/production/kustomization.yaml
+++ b/k8s/grafana/overlays/production/kustomization.yaml
@@ -75,6 +75,8 @@ patches:
     spec:
       template:
         spec:
+          nodeSelector:
+            eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
           containers:
             - name: grafana
               volumeMounts:


### PR DESCRIPTION
Pins Grafana scheduling to the AL2023 managed node group while preserving its existing image, configuration, and EBS-backed PVC