### PR TITLE
Migrate sandbox gitserver to AL2023

### DIFF
--- a/k8s/omegaup/overlays/sandbox/backend/gitserver-deployment.yaml
+++ b/k8s/omegaup/overlays/sandbox/backend/gitserver-deployment.yaml
@@ -4,7 +4,13 @@ kind: Deployment
 metadata:
   name: gitserver-deployment
 spec:
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/version: v1.9.17
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+        topology.kubernetes.io/zone: us-east-1b


### PR DESCRIPTION
Moves the sandbox gitserver to AL2023 nodes in us-east-1b and uses the Recreate strategy to safely remount its RWO EBS volume