### PR TITLE
Work around sandbox gitserver readiness failure

### DIFF
--- a/k8s/omegaup/overlays/sandbox/backend/gitserver-deployment.yaml
+++ b/k8s/omegaup/overlays/sandbox/backend/gitserver-deployment.yaml
@@ -14,3 +14,9 @@ spec:
       nodeSelector:
         eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
         topology.kubernetes.io/zone: us-east-1b
+      containers:
+      - name: gitserver
+        readinessProbe:
+          httpGet:
+            path: /health/live
+            port: gitserver


### PR DESCRIPTION
Temporarily uses the live health endpoint for sandbox gitserver readiness because the existing ready check fails its internal authentication test after restart