### PR TITLE
Run broadcaster on AL2023 nodes

### DIFF
--- a/k8s/omegaup/overlays/production/backend/broadcaster-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/broadcaster-deployment.yaml
@@ -8,3 +8,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/version: v1.9.66
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+      containers:
+      - name: broadcaster
+        resources:
+          limits:
+            memory: 64Mi


### PR DESCRIPTION
Moves the production broadcaster to the AL2023 node group and raises its memory limit from 32Mi to 64Mi after confirming historical OOM kills