### PR TITLE
Run production gitserver on AL2023

### DIFF
--- a/k8s/omegaup/overlays/production/backend/gitserver-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/gitserver-deployment.yaml
@@ -4,7 +4,20 @@ kind: Deployment
 metadata:
   name: gitserver-deployment
 spec:
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/version: v1.9.17
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
+        topology.kubernetes.io/zone: us-east-1a
+      containers:
+      - name: gitserver
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            memory: 512Mi


### PR DESCRIPTION
Moves the production gitserver to AL2023 nodes in us-east-1a, switches the single-replica EBS workload to Recreate, and increases memory after confirming historical OOM kills