### PR TITLE
Fix production gitserver readiness

### DIFF
--- a/k8s/omegaup/overlays/production/backend/gitserver-deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/gitserver-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       nodeSelector:
         eks.amazonaws.com/nodegroup: omegaup-eks-nodes-al2023
         topology.kubernetes.io/zone: us-east-1a
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: gitserver
         resources:
@@ -21,3 +23,6 @@ spec:
             memory: 1536Mi
           requests:
             memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /health/live


### PR DESCRIPTION
Uses the live health endpoint for production gitserver readiness after fresh startups return an internal authentication error, and avoids repeated recursive ownership changes on the 100 GiB volume