### PR TITLE
Add persistent grader NLB service

### DIFF
--- a/k8s/omegaup/overlays/production/backend/deployment.yaml
+++ b/k8s/omegaup/overlays/production/backend/deployment.yaml
@@ -2,6 +2,32 @@ apiVersion: v1
 kind: Service
 
 metadata:
+  name: grader-dns-alias
+  annotations:
+    # DNS is currently managed in GoDaddy. Keep this annotation so the
+    # Service is ready if external-dns is installed in the future.
+    external-dns.alpha.kubernetes.io/hostname: grader.omegaup.com
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  labels:
+    app.kubernetes.io/name: grader-runner
+    app.kubernetes.io/part-of: backend
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: grader
+  ports:
+  - name: grader-runner
+    protocol: TCP
+    port: 11302
+    targetPort: 11302
+---
+# Keep the historical Service until grader.omegaup.com has been moved to the
+# grader-dns-alias NLB and the runner fleet has been validated through it.
+apiVersion: v1
+kind: Service
+
+metadata:
   name: grader-runner-service
   labels:
     app.kubernetes.io/name: grader-runner


### PR DESCRIPTION
Adds the `grader-dns-alias` LoadBalancer Service to persist the public NLB used by external runners.

The historical `grader-runner-service` remains in place until `grader.omegaup.com` is migrated to the new NLB and runner connectivity is validated. This prevents future node replacements from leaving the grader endpoint without targets