### PR TITLE
Fix sandbox runner public IP lookup

### DIFF
--- a/k8s/omegaup/overlays/sandbox/backend/runner-deployment.yaml
+++ b/k8s/omegaup/overlays/sandbox/backend/runner-deployment.yaml
@@ -8,3 +8,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/version: v1.9.67
+    spec:
+      # runner v1.9.67 queries ifconfig.me without validating its response and
+      # can send an invalid OmegaUp-Runner-PublicIP header. Sandbox does not
+      # need a public runner address, so make that optional lookup fail fast
+      # until an image containing the upstream fix is published.
+      hostAliases:
+      - ip: 127.0.0.1
+        hostnames:
+        - ifconfig.me


### PR DESCRIPTION
Prevents runner v1.9.67 from sending an invalid `OmegaUp-Runner-PublicIP`
header in sandbox by disabling its outdated `ifconfig.me` lookup

This is a temporary mitigation until an image containing the upstream fix is
published