### PR TITLE
Use fixed runner image in sandbox

### DIFF
--- a/k8s/omegaup/overlays/sandbox/backend/kustomization.yaml
+++ b/k8s/omegaup/overlays/sandbox/backend/kustomization.yaml
@@ -84,4 +84,4 @@ images:
 - name: omegaup/gitserver
   newTag: v1.9.17
 - name: omegaup/runner
-  newTag: v1.9.67
+  newTag: v1.9.72

--- a/k8s/omegaup/overlays/sandbox/backend/runner-deployment.yaml
+++ b/k8s/omegaup/overlays/sandbox/backend/runner-deployment.yaml
@@ -7,13 +7,4 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/version: v1.9.67
-    spec:
-      # runner v1.9.67 queries ifconfig.me without validating its response and
-      # can send an invalid OmegaUp-Runner-PublicIP header. Sandbox does not
-      # need a public runner address, so make that optional lookup fail fast
-      # until an image containing the upstream fix is published.
-      hostAliases:
-      - ip: 127.0.0.1
-        hostnames:
-        - ifconfig.me
+        app.kubernetes.io/version: v1.9.72


### PR DESCRIPTION
Updates the sandbox runner to v1.9.72 and removes the temporary ifconfig.me host alias workaround