### PR TITLE
Protect expensive problem routes from crawlers

### DIFF
--- a/k8s/ingress-nginx/overlays/production/kustomization.yaml
+++ b/k8s/ingress-nginx/overlays/production/kustomization.yaml
@@ -8,3 +8,14 @@ commonLabels:
 
 bases:
 - ../../base
+
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ingress-nginx-controller
+      namespace: ingress-nginx
+    data:
+      http-snippet: |
+        limit_req_zone $server_name zone=omegaup_problem_global:10m rate=1r/s;

--- a/k8s/omegaup/overlays/production/frontend/kustomization.yaml
+++ b/k8s/omegaup/overlays/production/frontend/kustomization.yaml
@@ -13,6 +13,7 @@ commonLabels:
 resources:
 - ../../../base/frontend
 - database.yaml
+- problem-crawler-protection.yaml
 - redis-storage.yaml
 
 generators:

--- a/k8s/omegaup/overlays/production/frontend/problem-crawler-protection.yaml
+++ b/k8s/omegaup/overlays/production/frontend/problem-crawler-protection.yaml
@@ -11,6 +11,8 @@ metadata:
       if ($http_user_agent ~* "(Applebot|bingbot|Bytespider|OAI-SearchBot|Amazonbot|PetalBot|SemrushBot)") {
         return 429;
       }
+      limit_req zone=omegaup_problem_global burst=2 nodelay;
+      limit_req_status 429;
 spec:
   rules:
   - host: omegaup.com

--- a/k8s/omegaup/overlays/production/frontend/problem-crawler-protection.yaml
+++ b/k8s/omegaup/overlays/production/frontend/problem-crawler-protection.yaml
@@ -1,0 +1,108 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  # Keep the incident resource name so applying this manifest updates it in
+  # place instead of creating competing Ingress rules for the same paths.
+  name: frontend-problem-rate-limit
+  namespace: omegaup
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($http_user_agent ~* "(Applebot|bingbot|Bytespider|OAI-SearchBot|Amazonbot|PetalBot|SemrushBot)") {
+        return 429;
+      }
+spec:
+  rules:
+  - host: omegaup.com
+    http:
+      paths:
+      - path: /problem/
+        pathType: Exact
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/collection/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /api/problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+  - host: www.omegaup.com
+    http:
+      paths:
+      - path: /problem/
+        pathType: Exact
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/collection/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /api/problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+  - host: arena.omegaup.com
+    http:
+      paths:
+      - path: /problem/
+        pathType: Exact
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /problem/collection/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000
+      - path: /api/problem/list/
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 8000


### PR DESCRIPTION
## Summary

- Protects expensive problem listing and collection routes from known crawlers.
- Limits these routes globally to 1 request per second per hostname, with a burst of 2.
- Keeps the rest of omegaUp and normal navigation outside this rate limit.

## Context

Automated traffic repeatedly requested problem listings and collections using many combinations of filters. Some requests impersonated normal browsers, so identifying crawlers exclusively through the User-Agent was insufficient.

The traffic saturated RDS at 100% CPU and caused platform-wide timeouts. Applying this rate limit stopped new expensive requests from accumulating and allowed the database to recover.

## Validation

- Normal homepage request: `200`
- Normal API request: `200`
- Controlled problem-list request: `200`
- Excess concurrent requests to protected routes: `429`
- RDS and application latency recovered after applying the mitigation
- ingress-nginx remained healthy

## Deployment order

For a new deployment, apply the `ingress-nginx` production overlay before the frontend production overlay. The Ingress rule references the rate-limit zone declared in the ingress-nginx ConfigMap.